### PR TITLE
feat: add Clipboard onContentChanged listener

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {
   StyleSheet,
   Text,
@@ -8,7 +8,7 @@ import {
   Alert,
   SafeAreaView,
 } from 'react-native';
-import {useClipboard} from '@react-native-community/clipboard';
+import Clipboard, {useClipboard} from '@react-native-community/clipboard';
 
 export const App: React.FC = () => {
   const [text, setText] = useState('');
@@ -18,6 +18,13 @@ export const App: React.FC = () => {
     setString(text);
     Alert.alert(`Copied to clipboard: ${text}`);
   };
+
+  useEffect(() => {
+    const clipboardListener = Clipboard.addOnContentChangedListener(() => {
+      console.log('Clipboard content changed');
+    });
+    return () => clipboardListener.remove();
+  }, []);
 
   return (
     <SafeAreaView style={styles.container}>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -217,7 +217,7 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/jscallinvoker (= 0.61.5)
-  - RNCClipboard (1.1.0):
+  - RNCClipboard (1.2.0):
     - React
   - Yoga (1.14.0)
 
@@ -336,7 +336,7 @@ SPEC CHECKSUMS:
   React-RCTText: 9ccc88273e9a3aacff5094d2175a605efa854dbe
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
-  RNCClipboard: ce59f2a026e853ee1eec3c816df740c007ba4c66
+  RNCClipboard: e8d99575c2917c338e0765d37cf46ff932377d26
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
 PODFILE CHECKSUM: 79310af6b976c356911a8a833e9b99c3399fdda3

--- a/ios/RNCClipboard.h
+++ b/ios/RNCClipboard.h
@@ -2,8 +2,10 @@
 #define RNCClipboard_h
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RNCClipboard : NSObject <RCTBridgeModule>
+
+@interface RNCClipboard : RCTEventEmitter <RCTBridgeModule>
 
 @end
 

--- a/ios/RNCClipboard.m
+++ b/ios/RNCClipboard.m
@@ -15,6 +15,16 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;  // only do this if your module initialization relies on calling UIKit!
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"changedContent"];
+}
+
 RCT_EXPORT_METHOD(setString:(NSString *)content)
 {
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
@@ -26,6 +36,25 @@ RCT_EXPORT_METHOD(getString:(RCTPromiseResolveBlock)resolve
 {
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
   resolve((clipboard.string ? : @""));
+}
+
+- (void)startObserving
+{
+     [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleClipboardChangedNotification:)
+                                                     name:UIPasteboardChangedNotification
+                                                   object:nil];
+}
+
+- (void)stopObserving
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+
+- (void)handleClipboardChangedNotification:(NSNotification *)notification
+{
+  [self sendEventWithName:@"changedContent" body:notification.userInfo];
 }
 
 @end

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,5 +1,6 @@
-import NativeClipboard from './NativeClipboard';
+import NativeClipboard, {ClipboardEventEmitter} from './NativeClipboard';
 
+type Listener = () => void;
 /**
  * `Clipboard` gives you an interface for setting and getting content from Clipboard on both iOS and Android
  */
@@ -26,5 +27,21 @@ export const Clipboard = {
    */
   setString(content: string) {
     NativeClipboard.setString(content);
+  },
+
+  /**
+   * Add a listener for the event `onClipboardContentChanged`
+   * ```javascript
+   * useEffect(() => {
+   *   const clipboardListener = Clipboard.addOnContentChangedListener(() => {
+   *     console.log('Clipboard content changed');
+   *   });
+   *   return () => clipboardListener.remove();
+   * }, [])
+   * ```
+   * @param listener The callback function to be called when clipboard content changed
+   */
+  addOnContentChangedListener(listener: Listener) {
+    return ClipboardEventEmitter.addListener('changedContent', listener);
   },
 };

--- a/src/NativeClipboard.ts
+++ b/src/NativeClipboard.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {NativeModules} from 'react-native';
+import {NativeModules, NativeEventEmitter} from 'react-native';
 
 // Separated file for Native Clipboard to be ready to switch to Turbo Module when it becomes public
 // TODO: uncomment when Turbo module is available
@@ -10,4 +10,8 @@ import {NativeModules} from 'react-native';
 //   +setString: (content: string) => void;
 // }
 
+const ClipboardEventEmitter = new NativeEventEmitter(
+  NativeModules.RNCClipboard,
+);
+export {ClipboardEventEmitter};
 export default NativeModules.RNCClipboard;


### PR DESCRIPTION
# Overview
## Motivation
In out project, we needed a method to be notified when the user has copied something new to the clipboard. 

Therefore I forked this project and added a `addOnContentChangedListener` function to the `Clipboard` object which calls the handler gave as a parameter whenever the content of the clipboard changes. 

## Possible Improvements
One thing I am not quite happy about is that on Android I attach the listener for Clipboard change on the `onCreate()` function. It should attach when the first listener is added but I haven't found a solution for this.  

## Limitations
Unfortunately, as I found out after I implemented the feature, it is limited on IOS as the system won't let you run tasks/processes while your app is in the background, but the handler triggers if the clipboard changes content while your app is in foreground

# Test Plan
Here is a screenshot with type checking and linting:
![Screenshot 2020-03-29 at 12 15 26](https://user-images.githubusercontent.com/16940343/77845550-64f63680-71b8-11ea-93e6-224ba91b473a.png)


For testing functionality, I will be honest, at least on my system the example project isn't running. I kept getting an error similar to `NSLog` was not found. At first I thought that it was something wrong with my implementation but then I cloned the original project, ran the example project from there and the same problem occurred. 

I tested the functionality in our app (replaced the version from package.json with this fork) and it behaves as expected, i.e the handler is called when the content of the clipboard changes.  

I haven't implemented tests but I think the most suitable test is a detox test where the content of the clipboard changes and then expect an alert to popup on the phone screen when the app is in foreground

Please tell me if there is any other information I can provide. 