### PR TITLE
fix(android): java.lang.SecurityException not allowed to perform READ…

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
@@ -55,9 +55,13 @@ public class ClipboardModule extends ContextBaseJavaModule {
 
   @ReactMethod
   public void setString(String text) {
-    ClipData clipdata = ClipData.newPlainText(null, text);
-    ClipboardManager clipboard = getClipboardService();
-    clipboard.setPrimaryClip(clipdata);
+    try {
+      ClipData clipdata = ClipData.newPlainText(null, text);
+      ClipboardManager clipboard = getClipboardService();
+      clipboard.setPrimaryClip(clipdata);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
…_CLIPBOARD

# Overview
ISSUE: #54
platforms: android9 android10

# Cause
- APP A: foreground app
- APP B: background app which setup 'addPrimaryClipChangedListener'

1. APP A calls setPrimaryClipboard.
2. then ClipboardService will broadcast the event to PrimaryClipChangedListener (e.g. APP B) and will also make a call to AppOpsManager.noteOp to inform about READ_CLIPBOARD operation.
3. If the listener(APP B) is not allowed to READ_CLIPBOARD, AppOpsManager.noteOp will throw a SecurityException and will crash the foreground app(APP A).
 
btw：and the clipboard was set successful

# Test Plan
we can disable READ_CLIPBOARD permission manually for reproducing

# HOW TO DISABLE READ_CLIPBOARD：
step 1: connect adb
step 2: adb shell
step 3: cmd appops set app.package.name READ_CLIPBOARD deny
