### PR TITLE
Retrieve images from iOS Pasteboard

### DIFF
--- a/ios/RNCClipboard.m
+++ b/ios/RNCClipboard.m
@@ -28,6 +28,50 @@ RCT_EXPORT_METHOD(getString:(RCTPromiseResolveBlock)resolve
   resolve((clipboard.string ? : @""));
 }
 
+RCT_EXPORT_METHOD(getImagePNG:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
+{
+  NSString *pngPrefix = @"data:image/png;base64,";
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  UIImage *clipboardImage = clipboard.image;
+  if (!clipboardImage) {
+    resolve(NULL);
+  } else {
+    NSString *imageDataBase64 = [UIImagePNGRepresentation(clipboardImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    NSString *withPrefix = [pngPrefix stringByAppendingString:imageDataBase64];
+    resolve((withPrefix ? : NULL));
+  }
+}
+
+RCT_EXPORT_METHOD(getImageJPG:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
+{
+  NSString *jpgPrefix = @"data:image/jpeg;base64,";
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  UIImage *clipboardImage = clipboard.image;
+  if (!clipboardImage) {
+    resolve(NULL);
+  } else {
+    NSString *imageDataBase64 = [UIImageJPEGRepresentation(clipboardImage, 1.0) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    NSString *withPrefix = [jpgPrefix stringByAppendingString:imageDataBase64];
+    resolve((withPrefix ? : NULL));
+  }
+}
+
+RCT_EXPORT_METHOD(hasImage:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
+{
+  BOOL imagePresent = YES;
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  if (@available(iOS 10, *)) {
+    imagePresent = clipboard.hasImages;
+  } else {
+    UIImage *imageInPasteboard = clipboard.image;
+    imagePresent = imageInPasteboard != nil;
+  }
+  resolve([NSNumber numberWithBool: imagePresent]);
+}
+
 RCT_EXPORT_METHOD(hasString:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)
 {

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -16,6 +16,28 @@ export const Clipboard = {
     return NativeClipboard.getString();
   },
   /**
+   * Get clipboard image as PNG in base64, this method returns a `Promise`, so you can use following code to get clipboard content
+   * ```javascript
+   * async _getContent() {
+   *   var content = await Clipboard.getImagePNG();
+   * }
+   * ```
+   */
+  getImagePNG(): Promise<string> {
+    return NativeClipboard.getImagePNG();
+  },
+    /**
+   * Get clipboard image as JPG in base64, this method returns a `Promise`, so you can use following code to get clipboard content
+   * ```javascript
+   * async _getContent() {
+   *   var content = await Clipboard.getImageJPG();
+   * }
+   * ```
+   */
+  getImageJPG(): Promise<string> {
+    return NativeClipboard.getImageJPG();
+  },
+  /**
    * Set content of string type. You can use following code to set clipboard content
    * ```javascript
    * _setContent() {
@@ -38,6 +60,18 @@ export const Clipboard = {
    */
   hasString() {
     return NativeClipboard.hasString();
+  },
+  /**
+   * Returns whether the clipboard has an image or is empty.
+   * This method returns a `Promise`, so you can use following code to check clipboard content
+   * ```javascript
+   * async _hasContent() {
+   *   var hasContent = await Clipboard.hasImage();
+   * }
+   * ```
+   */
+  hasImage() {
+    return NativeClipboard.hasImage();
   },
   /**
    * (IOS Only)


### PR DESCRIPTION
# Overview
Added the ability to check if there is an image in the iOS Pasteboard and to retrieve clipboard image if it exists as base64 png/jpg.

# Test Plan
Tested each function with various cases (no image in clipboard, etc) with a simple test application and the behavior was as expected. Open to any ideas on corner cases to check/explore.