### PR TITLE
remove buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-    buildToolsVersion getExtOrDefault('buildToolsVersion')
 
     defaultConfig {
         minSdkVersion getExtOrIntegerDefault('minSdkVersion')


### PR DESCRIPTION
# Overview

Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.

# Test Plan

No visible changes, everything will works as before.