### PR TITLE
fix listener for older RN versions

### DIFF
--- a/src/NativeClipboard.ts
+++ b/src/NativeClipboard.ts
@@ -20,8 +20,19 @@ export default NativeModules.RNCClipboard;
 const EVENT_NAME = 'RNCClipboard_TEXT_CHANGED';
 const eventEmitter = new NativeEventEmitter(NativeModules.RNCClipboard);
 
+let listenerCount = eventEmitter.listenerCount;
+
+// listenerCount is only available from RN 0.64
+// Older versions only have `listeners`
+if (!listenerCount) {
+  listenerCount = (eventType: string) => {
+    // @ts-ignore
+    return eventEmitter.listeners(eventType).length;
+  };
+}
+
 const addListener = (callback: () => void): EmitterSubscription => {
-  if (eventEmitter.listenerCount(EVENT_NAME) === 0) {
+  if (listenerCount(EVENT_NAME) === 0) {
     NativeModules.RNCClipboard.setListener();
   }
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Fixes a `EventEmitter` usage to work with RN 0.64 and older. Refer to https://github.com/react-native-clipboard/clipboard/pull/97

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Tested on RN 0.62.2 and RN 0.64.2
