### PR TITLE
Fix even listener remove

### DIFF
--- a/src/NativeClipboard.ts
+++ b/src/NativeClipboard.ts
@@ -36,7 +36,21 @@ const addListener = (callback: () => void): EmitterSubscription => {
     NativeModules.RNCClipboard.setListener();
   }
 
-  return eventEmitter.addListener(EVENT_NAME, callback);
+  let res = eventEmitter.addListener(EVENT_NAME, callback);
+
+  // Path the remove call to also remove the native listener
+  // if we no longer have listeners
+  // @ts-ignore
+  res._remove = res.remove;
+  res.remove = function () {
+    // @ts-ignore
+    this._remove();
+    if (listenerCount(EVENT_NAME) === 0) {
+      NativeModules.RNCClipboard.removeListener();
+    }
+  };
+
+  return res;
 };
 
 const removeAllListeners = () => {


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Yet another fix for the event listener changes.  Make sure the `remove` call also clears the native listener if there are any left.

I could not find any useful API in the EventEmitter class to do this nicely, so the approach is to just patch the remove method to do the cleanup once it is the last listener. Any other ideas are welcome.

Code change that caused the bug initially: https://github.com/react-native-clipboard/clipboard/commit/08a2c005ea06f5e8501ff512f19f560dea22b700#diff-cdaf1c3ad4529370d3d7c0daa193662c1f00974d8975aa4bb588d00fc441ad44L26
Related: https://github.com/react-native-clipboard/clipboard/pull/104

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Tested `remove` calls on both iOS and Android.

@Naturalclar any ideas on how the cleanup code can be implemented without monkey-patching?