### PR TITLE
fix: calls to listenerCount throw for RN 0.64+

### DIFF
--- a/src/NativeClipboard.ts
+++ b/src/NativeClipboard.ts
@@ -29,6 +29,8 @@ if (!listenerCount) {
     // @ts-ignore
     return eventEmitter.listeners(eventType).length;
   };
+} else {
+  listenerCount = eventEmitter.listenerCount.bind(eventEmitter);
 }
 
 const addListener = (callback: () => void): EmitterSubscription => {


### PR DESCRIPTION
# Overview
if it's not polyfilled, extracted listenerCount will lose context, and `this` will be undefined.

# Test Plan
Before this change, calls like this

```
Clipboard.addListener(handler);
```

will throw on app with React native version of 0.64 or newer
