### PR TITLE
RN 0.65 update to silence warnings

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
@@ -102,7 +102,7 @@ public class ClipboardModule extends ContextBaseJavaModule {
   }
 
   @ReactMethod
-  void removeListener() {
+  public void removeListener() {
     if(listener != null){
       try{
         ClipboardManager clipboard = getClipboardService();
@@ -111,5 +111,15 @@ public class ClipboardModule extends ContextBaseJavaModule {
         e.printStackTrace();
       }
     }
+  }
+  
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Keep: Required for RN built in Event Emitter Calls.
   }
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Add stub methods for RN 0.65 warnings.  In the future, we may use these methods to improve the add/remove logic, but for now we should it like this to make it backwards compatible.

Also added a missing "public" identifier to silence a compiler warning.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Tested on Pixel 5 with RN 0.65.1
