### PR TITLE
Fix mock exports

### DIFF
--- a/__tests__/mock.test.js
+++ b/__tests__/mock.test.js
@@ -3,10 +3,10 @@ const mockClipboard = require('../jest/clipboard-mock');
 jest.mock('../dist/index.js', () => mockClipboard);
 
 describe('mockClipboard', () => {
-  const {Clipboard, useClipboard} = require('../dist/index.js');
+  const {getString, useClipboard} = require('../dist/index.js');
 
   it('can get mock string', async () => {
-    const result = await Clipboard.getString();
+    const result = await getString();
     const expected = 'mockString';
     expect(result).toBe(expected);
   });

--- a/jest/clipboard-mock.js
+++ b/jest/clipboard-mock.js
@@ -16,9 +16,11 @@ const ClipboardMock = {
   removeAllListeners: jest.fn(),
 };
 
-const RNCClipboardMock = {};
+const useClipboard = jest.fn(() => ['mockString', jest.fn()]);
 
-RNCClipboardMock.Clipboard = ClipboardMock;
-RNCClipboardMock.useClipboard = jest.fn(() => ['mockString', jest.fn()]);
+const RNCClipboardMock = {
+  ...ClipboardMock,
+  useClipboard,
+};
 
 module.exports = RNCClipboardMock;


### PR DESCRIPTION
# Overview

In the previous mock, the clipboard methods (except the hook) were exposed under `Clipboard` key.
As a consequence the mock was not working.

Why ? 

If you look in the file (index.ts)[https://github.com/react-native-clipboard/clipboard/blob/master/src/index.ts], these methods are exported as default, **NOT** under a Clipboard key.


# Test Plan

I fixed the test file but it is not very usefull because it do not really mock the module.
It just test an implementation (the mock implementation).
Do not know for the moment how to improve this part.

Any idea ? 
