### PR TITLE
chore(android): replaced jCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         google()
+	mavenCentral()
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
     }
 
     dependencies {
@@ -30,7 +29,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
# Overview

jCenter will be offline in February 2022. I've updated the android project to use maven.

# Test Plan

I've tested the library on a personal project and it builds without issues.
