### PR TITLE
feat: getStrings + setStrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,20 @@ async _getContent() {
 }
 ```
 
----
+#### `getStrings()`
+
+```jsx
+static getStrings()
+```
+
+(iOS only)
+Get contents of string array type, this method returns a `Promise`, so you can use following code to get clipboard content
+
+```jsx
+async _getContent() {
+  var content = await Clipboard.getStrings();
+}
+```
 
 #### `setString()`
 
@@ -180,6 +193,28 @@ _setContent() {
 | Name    | Type   | Required | Description                               |
 | ------- | ------ | -------- | ----------------------------------------- |
 | content | string | Yes      | The content to be stored in the clipboard |
+
+#### `setStrings()`
+
+```jsx
+static setStrings(content)
+```
+
+(iOS only)
+Set content of string array type. You can use following code to set clipboard content
+
+```jsx
+_setContent() {
+  Clipboard.setStrings(['hello world', 'second string']);
+}
+```
+
+#### Parameters
+
+| Name    | Type     | Required | Description                               |
+| ------- | -------- | -------- | ----------------------------------------- |
+| content | string[] | Yes      | The content to be stored in the clipboard |
+
 
 #### `hasString()`
 

--- a/ios/RNCClipboard.m
+++ b/ios/RNCClipboard.m
@@ -73,6 +73,19 @@ RCT_EXPORT_METHOD(getString:(RCTPromiseResolveBlock)resolve
   resolve((clipboard.string ? : @""));
 }
 
+RCT_EXPORT_METHOD(setStrings:(NSArray<NSString *> *)array)
+{
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  clipboard.strings = (array ? : @[]);
+}
+
+RCT_EXPORT_METHOD(getStrings:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
+{
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  resolve((clipboard.strings ? : @[]));
+}
+
 RCT_EXPORT_METHOD(setImage:(NSString *)content
     resolve:(RCTPromiseResolveBlock) resolve
     reject:(RCTPromiseRejectBlock) reject

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -20,6 +20,18 @@ export const Clipboard = {
     return NativeClipboard.getString();
   },
   /**
+   * (iOS Only)
+   * Get contents of string array type, this method returns a `Promise`, so you can use following code to get clipboard content
+   * ```javascript
+   * async _getContent() {
+   *   var content = await Clipboard.getStrings();
+   * }
+   * ```
+   */
+  getStrings(): Promise<string[]> {
+    return NativeClipboard.getStrings();
+  },
+  /**
    * Get clipboard image as PNG in base64, this method returns a `Promise`, so you can use following code to get clipboard content
    * ```javascript
    * async _getContent() {
@@ -42,13 +54,12 @@ export const Clipboard = {
     return NativeClipboard.getImageJPG();
   },
   /**
+   * (iOS Only)
    * Set content of base64 image type. You can use following code to set clipboard content
    * ```javascript
    * _setContent() {
    *   Clipboard.setImage(...);
    * }
-   *
-   * iOS only
    * ```
    * @param the content to be stored in the clipboard.
    */
@@ -84,6 +95,18 @@ export const Clipboard = {
     NativeClipboard.setString(content);
   },
   /**
+   * Set content of string array type. You can use following code to set clipboard content
+   * ```javascript
+   * _setContent() {
+   *   Clipboard.setStrings(['hello world', 'second string']);
+   * }
+   * ```
+   * @param the content to be stored in the clipboard.
+   */
+  setStrings(content: string[]) {
+    NativeClipboard.setStrings(content);
+  },
+  /**
    * Returns whether the clipboard has content or is empty.
    * This method returns a `Promise`, so you can use following code to get clipboard content
    * ```javascript
@@ -108,7 +131,7 @@ export const Clipboard = {
     return NativeClipboard.hasImage();
   },
   /**
-   * (IOS Only)
+   * (iOS Only)
    * Returns whether the clipboard has a URL content. Can check
    * if there is a URL content in clipboard without triggering PasteBoard notification for iOS 14+
    * This method returns a `Promise`, so you can use following code to check for url content in clipboard.
@@ -125,7 +148,7 @@ export const Clipboard = {
     return NativeClipboard.hasURL();
   },
   /**
-   * (IOS 14+ Only)
+   * (iOS 14+ Only)
    * Returns whether the clipboard has a Number(UIPasteboardDetectionPatternNumber) content. Can check
    * if there is a Number content in clipboard without triggering PasteBoard notification for iOS 14+
    * This method returns a `Promise`, so you can use following code to check for Number content in clipboard.
@@ -142,7 +165,7 @@ export const Clipboard = {
     return NativeClipboard.hasNumber();
   },
   /**
-   * (IOS 14+ Only)
+   * (iOS 14+ Only)
    * Returns whether the clipboard has a WebURL(UIPasteboardDetectionPatternProbableWebURL) content. Can check
    * if there is a WebURL content in clipboard without triggering PasteBoard notification for iOS 14+
    * This method returns a `Promise`, so you can use following code to check for WebURL content in clipboard.


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
feature: getStrings + setStrings (iOS only)

iOS's native clipboard API supports string array, so here I add wrapper methods for it.

```
@property(nullable,nonatomic,copy) NSArray<NSString *> *strings API_UNAVAILABLE(tvos) API_UNAVAILABLE(watchos);
```