### PR TITLE
Fix: Allow Clipboard module to be used with targetSdkVersion 30

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
@@ -133,7 +133,7 @@ public class ClipboardModule extends ReactContextBaseJavaModule {
                   bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
                   break;
                 case MIMETYPE_WEBP:
-                  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R){
+                  if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q){
                     bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSLESS, 100, outputStream);
                     break;
                   }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Fixes #151 

Fix: Allow Clipboard module to be used with targetSdkVersion 30

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
