### PR TITLE
new arch. support for ios and android config

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@react-native-community/eslint-config": "^2.0.0",
-    "@types/react-native": "^0.64.8",
+    "@types/react-native": "^0.68.0",
     "babel-jest": "^26.1.0",
     "eslint": "^7.32.0",
     "eslint-plugin-prettier": "^3.1.2",
@@ -55,7 +55,7 @@
     "metro-react-native-babel-preset": "^0.64.0",
     "prettier": "^2.4.1",
     "react": "17.0.1",
-    "react-native": "0.64.1",
+    "react-native": "0.68.0",
     "react-native-macos": "^0.62.0-0",
     "react-native-windows": "^0.64.0",
     "react-test-renderer": "16.9.0",
@@ -67,5 +67,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "codegenConfig": {
+    "name": "RNCClipboard",
+    "type": "all",
+    "jsSrcsDir": ".",
+    "android": {
+      "javaPackageName": "com.reactnativecommunity.clipboard"
+    }
   }
 }

--- a/src/NativeClipboard.ts
+++ b/src/NativeClipboard.ts
@@ -4,18 +4,20 @@ import {
   NativeModules,
   NativeEventEmitter,
   EmitterSubscription,
+  TurboModuleRegistry,
 } from 'react-native';
+import type { TurboModule } from 'react-native/Libraries/TurboModule/RCTExport';
 
-// Separated file for Native Clipboard to be ready to switch to Turbo Module when it becomes public
-// TODO: uncomment when Turbo module is available
-// export interface Spec extends TurboModule {
-//   +getConstants: () => {||};
-//   +getString: () => Promise<string>;
-//   +setString: (content: string) => void;
-//   +hasString: () => Promise<boolean>;
-// }
+export interface Spec extends TurboModule {
+  getConstants: () => {};
+  getString: () => Promise<string>;
+  setString: (content: string) => void;
+  hasString: () => Promise<boolean>;
+}
 
-export default NativeModules.RNCClipboard;
+export default TurboModuleRegistry.get<Spec>(
+  'RNCClipboard'
+) as Spec | null;
 
 const EVENT_NAME = 'RNCClipboard_TEXT_CHANGED';
 const eventEmitter = new NativeEventEmitter(NativeModules.RNCClipboard);


### PR DESCRIPTION
# Overview

I have added the Turbo Module support since it's officially released from RN version 0.68 and upgraded the ReactNative version to 0.68.

# Test Plan

Tested the Turbo Module support in iOS and Android platforms only Windows and macOS are still remaining.