### PR TITLE
Remove windows specified Platform Toolset

### DIFF
--- a/windows/Clipboard/Clipboard.vcxproj
+++ b/windows/Clipboard/Clipboard.vcxproj
@@ -54,9 +54,6 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>


### PR DESCRIPTION
# Overview
Clipboard has been using an older toolset which is becoming outdated and causing ` Error MSB8036: The Windows SDK version 10.0.18362.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution` in React-Native-Windows .71 and any future versions.

The fix is to remove the specified toolset and use the standard version.


# Test Plan
Tested locally on React-Native-Windows Gallery and in a React-Native .68 application. Looks like example app is broken in this repository.