### PR TITLE
Fix setString on Windows by dispatching to UI thread

### DIFF
--- a/windows/Clipboard/Clipboard.cpp
+++ b/windows/Clipboard/Clipboard.cpp
@@ -8,7 +8,7 @@ namespace NativeClipboard {
     if (dataPackageView.Contains(datatransfer::StandardDataFormats::Text())) {
       dataPackageView.GetTextAsync().Completed([promise, dataPackageView](IAsyncOperation<winrt::hstring> info, AsyncStatus status) {
         if (status == AsyncStatus::Completed) {
-          auto text = Microsoft::Common::Unicode::Utf16ToUtf8(info.GetResults());
+          auto text = winrt::to_string(info.GetResults());
           promise.Resolve(text);
         }
         else {
@@ -24,7 +24,7 @@ namespace NativeClipboard {
   {
     _context.UIDispatcher().Post([str](){
       datatransfer::DataPackage dataPackage{};
-      dataPackage.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(str));
+      dataPackage.SetText(winrt::to_hstring(str));
       datatransfer::Clipboard::SetContent(dataPackage);
     });
   }

--- a/windows/Clipboard/Clipboard.cpp
+++ b/windows/Clipboard/Clipboard.cpp
@@ -22,8 +22,10 @@ namespace NativeClipboard {
 
   void ClipboardModule::SetString(std::string const& str) noexcept
   {
-    datatransfer::DataPackage dataPackage{};
-    dataPackage.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(str));
-    datatransfer::Clipboard::SetContent(dataPackage);
+    _context.UIDispatcher().Post([str](){
+      datatransfer::DataPackage dataPackage{};
+      dataPackage.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(str));
+      datatransfer::Clipboard::SetContent(dataPackage);
+    });
   }
 }

--- a/windows/Clipboard/Clipboard.h
+++ b/windows/Clipboard/Clipboard.h
@@ -16,11 +16,19 @@ namespace NativeClipboard {
   REACT_MODULE(ClipboardModule, L"RNCClipboard");
   struct ClipboardModule
   {
+    REACT_INIT(Initialize);
+    void Initialize(const winrt::Microsoft::ReactNative::ReactContext& reactContext) noexcept
+    {
+      _context = reactContext;
+    }
 
     REACT_METHOD(GetString, L"getString");
     void GetString(React::ReactPromise<std::string>&& result) noexcept;
 
     REACT_METHOD(SetString, L"setString");
     void SetString(std::string const& str) noexcept;
+
+  private:
+    ReactContext _context;
   };
 }


### PR DESCRIPTION
# Overview
Fixes #173

# Test Plan
I have made this change locally in my Windows app and validated this fixes the crash.
I also tested `getString`, which already worked and needed to changes.