### PR TITLE
Fix warnings: new NativeEventEmitter() was called with a non-null arg…

### DIFF
--- a/windows/Clipboard/Clipboard.cpp
+++ b/windows/Clipboard/Clipboard.cpp
@@ -26,4 +26,17 @@ namespace NativeClipboard {
     dataPackage.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(str));
     datatransfer::Clipboard::SetContent(dataPackage);
   }
+
+  void ClipboardModule::AddListener(std::string const& event) noexcept
+  {
+    _listenerCount++;
+  }
+
+  void ClipboardModule::RemoveListeners(int count) noexcept
+  {
+    _listenerCount--;
+    if (_listenerCount == 0) {
+      // Disconnect any native eventing here
+    }
+  }
 }

--- a/windows/Clipboard/Clipboard.h
+++ b/windows/Clipboard/Clipboard.h
@@ -22,5 +22,14 @@ namespace NativeClipboard {
 
     REACT_METHOD(SetString, L"setString");
     void SetString(std::string const& str) noexcept;
+
+    REACT_METHOD(AddListener, L"addListener");
+    void AddListener(std::string const& event) noexcept;
+
+    REACT_METHOD(RemoveListeners, L"removeListeners");
+    void RemoveListeners(int count) noexcept;
+
+  private:
+    int _listenerCount = 0;
   };
 }


### PR DESCRIPTION
# Overview
For #116 (Windows only fix, Android already fixed, iOS still broken based on the thread)

There are no native events doing listening in the Windows implementation, but the methods still need to be present. Added `addListener` and `removeListeners` stubs, which supresses the warning (similar to fix made for Android:
https://github.com/react-native-clipboard/clipboard/pull/113

# Test Plan
Applied the change to a Windows app that was using Clipboard and triggering the warning.