### PR TITLE
Use existing clipData instead of calling getPrimaryClip() again

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
@@ -69,7 +69,7 @@ public class ClipboardModule extends ReactContextBaseJavaModule {
       ClipboardManager clipboard = getClipboardService();
       ClipData clipData = clipboard.getPrimaryClip();
       if (clipData != null && clipData.getItemCount() >= 1) {
-        ClipData.Item firstItem = clipboard.getPrimaryClip().getItemAt(0);
+        ClipData.Item firstItem = clipData.getItemAt(0);
         promise.resolve("" + firstItem.getText());
       } else {
         promise.resolve("");


### PR DESCRIPTION
# Overview
Notice that in the line `ClipData.Item firstItem = clipboard.getPrimaryClip().getItemAt(0);`, you're calling `getPrimaryClip()` again instead of using the already retrieved `clipData` object. If there's no primary clip at this point (it could have been changed by another process or thread after the initial `getPrimaryClip()` call), `getPrimaryClip()` will return `null`, and trying to call `getItemAt(0)` on it will result in the error you're seeing.

Error log:
```
Attempt to invoke virtual method 'android.content.ClipData$Item android.content.ClipData.getItemAt(int)' on a null object reference
```