### PR TITLE
Fix warnings: new NativeEventEmitter() was called with a non-null argument

### DIFF
--- a/ios/RNCClipboard.m
+++ b/ios/RNCClipboard.m
@@ -213,6 +213,13 @@ RCT_EXPORT_METHOD(hasWebURL:(RCTPromiseResolveBlock)resolve
   
 }
 
+RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
+RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
 
 
 

--- a/macos/RNCClipboard.m
+++ b/macos/RNCClipboard.m
@@ -31,4 +31,12 @@ RCT_EXPORT_METHOD(getString:(RCTPromiseResolveBlock)resolve
   resolve(([pasteboard stringForType:NSPasteboardTypeString] ? : @""));
 }
 
+RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
+RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
 @end


### PR DESCRIPTION
# Overview
Fixes #116 
Similar fix applied on #175 but for iOS/Macos supresses the NativeEventEmitter warning
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
Build/Open the  Macos or iOS apps and you should see no warning

Reference: https://github.com/react-native-netinfo/react-native-netinfo/pull/487
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
