### PR TITLE
Add macOS back to podspec platforms

### DIFF
--- a/RNCClipboard.podspec
+++ b/RNCClipboard.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
 
     install_modules_dependencies(s)
   else
-    s.platforms = { :ios => "9.0", :tvos => "9.0" }
+    s.platforms = { :ios => "9.0", :tvos => "9.0", :osx => "10.14" }
 
     s.dependency "React-Core"
   end


### PR DESCRIPTION
# Overview

https://github.com/react-native-clipboard/clipboard/commit/7f84dabcee9789ed9933ff236f5fad373e1400b1 accidentally removed the `osx` key from the defined platforms inside the podspec


# Test Plan

Run pod install in a macOS project and ensure that RNCClipboard is not removed 
