### PR TITLE
add missing `getEnforcing` jest mock

### DIFF
--- a/jest/clipboard-mock.js
+++ b/jest/clipboard-mock.js
@@ -14,6 +14,7 @@ const ClipboardMock = {
   hasURL: jest.fn().mockResolvedValue(true),
   addListener: jest.fn(),
   removeAllListeners: jest.fn(),
+  getEnforcing: jest.fn(),
 };
 
 const useClipboard = jest.fn(() => ['mockString', jest.fn()]);


### PR DESCRIPTION
# Overview

we recently switched our clipboard library from `@react-native-community/clipboard` to `@react-native-clipboard/clipboard`. On running our unit test suite I noticed this error : 

```
/Users/siddarthkumar/code/experiments/status-mobile/target/unit_test/test.js:67
    throw e;
    ^

TypeError: Cannot read properties of undefined (reading 'getEnforcing')
    at Object.<anonymous> (/Users/siddarthkumar/code/experiments/status-mobile/node_modules/
    @react-native-clipboard/clipboard/dist/NativeClipboardModule.js:5:63)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.hookedLoader [as _load] (/Users/siddarthkumar/code/experiments/status-mobile/
    test-resources/override.js:16:10)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at Module.require (/Users/siddarthkumar/code/experiments/status-mobile/test-resources/override.js:24:28)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/Users/siddarthkumar/code/experiments/status-mobile/node_modules/
    @react-native-clipboard/clipboard/dist/Clipboard.js:24:44)

Node.js v18.16.0
make: *** [_test-clojure] Error 1
```

This PR adds `getEnforcing` to the jest mock exports which fixes this error.

reference in status-mobile repo -> https://github.com/status-im/status-mobile/pull/18496/commits/16d927d5f822b03df97d5b52cc4dbdf6fb47df16

# Test Plan
no extensive tests needed this PR just adds a missing function to jest exports.