### PR TITLE
fix: module spec mis-match on Android (new Architecture)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
@@ -238,7 +238,7 @@ public class ClipboardModule extends NativeClipboardModuleSpec {
   }
 
   @Override
-  public void removeListeners(double count) {
+  public void removeListeners(int count) {
 
   }
 

--- a/android/src/paper/java/com/reactnativecommunity/clipboard/NativeClipboardModuleSpec.java
+++ b/android/src/paper/java/com/reactnativecommunity/clipboard/NativeClipboardModuleSpec.java
@@ -17,11 +17,10 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 
-public abstract class NativeClipboardModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeClipboardModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public NativeClipboardModuleSpec(ReactApplicationContext reactContext) {
     super(reactContext);
   }
@@ -92,5 +91,5 @@ public abstract class NativeClipboardModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
-  public abstract void removeListeners(double count);
+  public abstract void removeListeners(int count);
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
I get the following build error on Android with **new architecture** enabled.
Created a test app using the guide here: https://gist.github.com/cipolleschi/82b7a9561b8861330efabbd3eb08c6f5#file-test-your-library-against-react-native-0-74-0-rcs-md
RN version: 0.74.0-rc.9

```
/src/ClipboardTest/node_modules/@react-native-clipboard/clipboard/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java:39: error: ClipboardModule is not abstract and does not override abstract method removeListeners(int) in NativeClipboardModuleSpec
public class ClipboardModule extends NativeClipboardModuleSpec {
       ^
/src/ClipboardTest/node_modules/@react-native-clipboard/clipboard/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java:240: error: method does not override or implement a method from a supertype
  @Override
  ^
```

This is due to mismatch with JS Spec in `NativeClipboardModule.ts`:
`removeListeners(count: Int32): void;`

Where as NativeClipboardModuleSpec.java defines as `public abstract void removeListeners(float count);`

==> Update `float` to `int` so both legacy and new architecture is using the same type defined in the spec.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->


Created a test app using the guide here: https://gist.github.com/cipolleschi/82b7a9561b8861330efabbd3eb08c6f5#file-test-your-library-against-react-native-0-74-0-rcs-md