### PR TITLE
chore: Update AndroidManifest.xml to support AGP > 8

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactnativecommunity.clipboard">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
# Overview
When building with Gradle > 8 we get this error:

```
Execution failed for task ':@react-native-community_clipboard:processDebugManifest'.
> A failure occurred while executing com.android.build.gradle.tasks.ProcessLibraryManifest$ProcessLibWorkAction
   > Incorrect package="com.reactnativecommunity.clipboard" found in source AndroidManifest.xml: /node_modules/@react-native-community/clipboard/android/src/main/AndroidManifest.xml.
     Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
     Recommendation: remove package="com.reactnativecommunity.clipboard" from the source AndroidManifest.xml: node_modules/@react-native-community/clipboard/android/src/main/AndroidManifest.xml.
```


# Test Plan
I removed this line: `package="com.reactnativecommunity.clipboard` and the error went away.