### PR TITLE
Update ClipboardModule.java

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
@@ -238,7 +238,7 @@ public class ClipboardModule extends NativeClipboardModuleSpec {
   }
 
   @Override
-  public void removeListeners(int count) {
+  public void removeListeners(double count) {
 
   }
 


### PR DESCRIPTION
Change removeListener arg from int to double due to NewArch changes

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

New Arch in 0.73 causes some issues due to type checking. Simply changed from Int to Double since the error mention it as well as the recommendation from [#238](https://github.com/react-native-clipboard/clipboard/issues/238#issuecomment-2083704956l)

```
.../node_modules/@react-native-clipboard/clipboard/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java:39: error: ClipboardModule is not abstract and does not override abstract method removeListeners(double) in NativeClipboardModuleSpec
public class ClipboardModule extends NativeClipboardModuleSpec {
       ^
.../node_modules/@react-native-clipboard/clipboard/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java:240: error: method does not override or implement a method from a supertype
  @Override
  ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: .../node_modules/@react-native-clipboard/clipboard/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardPackage.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors

```


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Did not do any testing other then standard app usage. Before this change, I couldn't build. Now I can and everything works as anticipated
