### PR TITLE
feat: getImage iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ _setContent() {
 | ------- | -------- | -------- | ----------------------------------------- |
 | content | string[] | Yes      | The content to be stored in the clipboard |
 
-
 #### `hasString()`
 
 ```jsx
@@ -255,8 +254,6 @@ static hasWebURL()
 Returns whether the clipboard has a WebURL(UIPasteboardDetectionPatternProbableWebURL) content.
 Can check if there is a WebURL content in clipboard without triggering PasteBoard notification for iOS 14+
 
-
-
 ### useClipboard
 
 `useClipboard` is a utility hooks for the `Clipboard` module. `data` contains the content stored in the clipboard.
@@ -283,7 +280,7 @@ export const HooksSample = () => {
 static getImage()
 ```
 
-Get content of image in base64 string type, this method returns a `Promise`, so you can use following code to get clipboard content (ANDROID only)
+Get content of image in base64 string type, this method returns a `Promise`, so you can use following code to get clipboard content (iOS and Android Only)
 
 ```jsx
 async _getContent() {

--- a/ios/RNCClipboard.mm
+++ b/ios/RNCClipboard.mm
@@ -1,6 +1,6 @@
 #import "RNCClipboard.h"
 
-
+#import <MobileCoreServices/UTType.h>
 #import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
@@ -216,45 +216,19 @@ RCT_EXPORT_METHOD(hasWebURL:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getImage:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject){
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
-  NSArray *clipboardTypes = [clipboard pasteboardTypes];
-  if ([clipboardTypes containsObject:@"com.compuserve.gif"]) {
-     NSString *uriPrefix = @"data:image/gif;base64,";
-     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"com.compuserve.gif"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
-     resolve((withPrefix ? : NULL));
-  } else if ([clipboardTypes containsObject:@"public.png"]) {
-     NSString *uriPrefix = @"data:image/png;base64,";
-     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.png"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
-     resolve((withPrefix ? : NULL));
-  } else if ([clipboardTypes containsObject:@"public.jpeg"]) {
-     NSString *uriPrefix = @"data:image/jpeg;base64,";
-     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.jpeg"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
-     resolve((withPrefix ? : NULL));
-  } else if ([clipboardTypes containsObject:@"org.webmproject.webp"]) {
-     NSString *uriPrefix = @"data:image/webp;base64,";
-     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"org.webmproject.webp"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
-     resolve((withPrefix ? : NULL));
-  } else if ([clipboardTypes containsObject:@"public.tiff"]) {
-     NSString *uriPrefix = @"data:image/tiff;base64,";
-     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.tiff"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
-     resolve((withPrefix ? : NULL));
-  } else if ([clipboardTypes containsObject:@"com.microsoft.bmp"]) {
-     NSString *uriPrefix = @"data:image/bmp;base64,";
-     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"com.microsoft.bmp"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
-     resolve((withPrefix ? : NULL));
-  } else if ([clipboardTypes containsObject:@"public.svg-image"]) {
-     NSString *uriPrefix = @"data:image/svg+xml;base64,";
-     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.svg-image"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
-     resolve((withPrefix ? : NULL));
-  } else {
-    reject(@"Clipboard:getImage", @"Unsupported image type", nil);
+  NSString *withPrefix;
+  for (NSItemProvider *itemProvider in [clipboard itemProviders]) {
+    if ([itemProvider canLoadObjectOfClass:[UIImage class]]) {
+      NSString *identifier = itemProvider.registeredTypeIdentifiers.firstObject;
+      if (identifier != nil) {
+        NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
+        NSString *imageDataBase64 = [[clipboard dataForPasteboardType:identifier] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+        withPrefix = [NSString stringWithFormat:@"data:%@;base64,%@", MIMEType, imageDataBase64];
+      }
+      break;
+    }
   }
+  resolve((withPrefix ? : NULL));
 }
 
 RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {

--- a/ios/RNCClipboard.mm
+++ b/ios/RNCClipboard.mm
@@ -1,5 +1,6 @@
 #import "RNCClipboard.h"
 
+#import <MobileCoreServices/MobileCoreServices.h>
 #import <MobileCoreServices/UTType.h>
 #import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
@@ -217,13 +218,15 @@ RCT_EXPORT_METHOD(getImage:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject){
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
   NSString *withPrefix;
-  for (NSItemProvider *itemProvider in [clipboard itemProviders]) {
-    if ([itemProvider canLoadObjectOfClass:[UIImage class]]) {
-      NSString *identifier = itemProvider.registeredTypeIdentifiers.firstObject;
-      if (identifier != nil) {
-        NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-        NSString *imageDataBase64 = [[clipboard dataForPasteboardType:identifier] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-        withPrefix = [NSString stringWithFormat:@"data:%@;base64,%@", MIMEType, imageDataBase64];
+  for (NSItemProvider *itemProvider in clipboard.itemProviders) {
+    if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
+      for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
+        if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeImage)) {
+          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
+          NSString *imageDataBase64 = [[clipboard dataForPasteboardType:identifier] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+          withPrefix = [NSString stringWithFormat:@"data:%@;base64,%@", MIMEType, imageDataBase64];
+          break;
+        }
       }
       break;
     }

--- a/ios/RNCClipboard.mm
+++ b/ios/RNCClipboard.mm
@@ -215,7 +215,26 @@ RCT_EXPORT_METHOD(hasWebURL:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(getImage:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject){
-  reject(@"Clipboard:getImage", @"getImage is not supported on iOS", nil);
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  UIImage *clipboardImage = clipboard.image;
+  if (!clipboardImage) {
+    resolve(NULL);
+  } else {
+    NSArray *clipboardTypes = [clipboard pasteboardTypes];
+    if ([clipboardTypes containsObject:@"public.png"]) {
+      NSString *pngPrefix = @"data:image/png;base64,";
+      NSString *imageDataBase64 = [UIImagePNGRepresentation(clipboardImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+      NSString *withPrefix = [pngPrefix stringByAppendingString:imageDataBase64];
+      resolve((withPrefix ? : NULL));
+    } else if ([clipboardTypes containsObject:@"public.jpeg"]) {
+      NSString *jpgPrefix = @"data:image/jpeg;base64,";
+      NSString *imageDataBase64 = [UIImageJPEGRepresentation(clipboardImage, 1.0) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+      NSString *withPrefix = [jpgPrefix stringByAppendingString:imageDataBase64];
+      resolve((withPrefix ? : NULL));
+    } else {
+      reject(@"Clipboard:getImage", @"Unsupported image type", nil);
+    }
+  }
 }
 
 RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {

--- a/ios/RNCClipboard.mm
+++ b/ios/RNCClipboard.mm
@@ -216,24 +216,44 @@ RCT_EXPORT_METHOD(hasWebURL:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getImage:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject){
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
-  UIImage *clipboardImage = clipboard.image;
-  if (!clipboardImage) {
-    resolve(NULL);
+  NSArray *clipboardTypes = [clipboard pasteboardTypes];
+  if ([clipboardTypes containsObject:@"com.compuserve.gif"]) {
+     NSString *uriPrefix = @"data:image/gif;base64,";
+     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"com.compuserve.gif"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
+     resolve((withPrefix ? : NULL));
+  } else if ([clipboardTypes containsObject:@"public.png"]) {
+     NSString *uriPrefix = @"data:image/png;base64,";
+     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.png"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
+     resolve((withPrefix ? : NULL));
+  } else if ([clipboardTypes containsObject:@"public.jpeg"]) {
+     NSString *uriPrefix = @"data:image/jpeg;base64,";
+     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.jpeg"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
+     resolve((withPrefix ? : NULL));
+  } else if ([clipboardTypes containsObject:@"org.webmproject.webp"]) {
+     NSString *uriPrefix = @"data:image/webp;base64,";
+     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"org.webmproject.webp"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
+     resolve((withPrefix ? : NULL));
+  } else if ([clipboardTypes containsObject:@"public.tiff"]) {
+     NSString *uriPrefix = @"data:image/tiff;base64,";
+     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.tiff"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
+     resolve((withPrefix ? : NULL));
+  } else if ([clipboardTypes containsObject:@"com.microsoft.bmp"]) {
+     NSString *uriPrefix = @"data:image/bmp;base64,";
+     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"com.microsoft.bmp"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
+     resolve((withPrefix ? : NULL));
+  } else if ([clipboardTypes containsObject:@"public.svg-image"]) {
+     NSString *uriPrefix = @"data:image/svg+xml;base64,";
+     NSString *imageDataBase64 = [[clipboard dataForPasteboardType:@"public.svg-image"] base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+     NSString *withPrefix = [uriPrefix stringByAppendingString:imageDataBase64];
+     resolve((withPrefix ? : NULL));
   } else {
-    NSArray *clipboardTypes = [clipboard pasteboardTypes];
-    if ([clipboardTypes containsObject:@"public.png"]) {
-      NSString *pngPrefix = @"data:image/png;base64,";
-      NSString *imageDataBase64 = [UIImagePNGRepresentation(clipboardImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-      NSString *withPrefix = [pngPrefix stringByAppendingString:imageDataBase64];
-      resolve((withPrefix ? : NULL));
-    } else if ([clipboardTypes containsObject:@"public.jpeg"]) {
-      NSString *jpgPrefix = @"data:image/jpeg;base64,";
-      NSString *imageDataBase64 = [UIImageJPEGRepresentation(clipboardImage, 1.0) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-      NSString *withPrefix = [jpgPrefix stringByAppendingString:imageDataBase64];
-      resolve((withPrefix ? : NULL));
-    } else {
-      reject(@"Clipboard:getImage", @"Unsupported image type", nil);
-    }
+    reject(@"Clipboard:getImage", @"Unsupported image type", nil);
   }
 }
 

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -71,7 +71,7 @@ export const Clipboard = {
     NativeClipboard.setImage(content);
   },
   /**
-   * (Android Only)
+   * (iOS and Android Only)
    * Get clipboard image in base64, this method returns a `Promise`, so you can use following code to get clipboard content
    * ```javascript
    * async _getContent() {

--- a/src/NativeClipboardModule.ts
+++ b/src/NativeClipboardModule.ts
@@ -59,7 +59,7 @@ export interface Spec extends TurboModule {
    */
   setImage(content: string): Promise<void>;
   /**
-   * (Android Only)
+   * (iOS and Android Only)
    * Get clipboard image in base64, this method returns a `Promise`, so you can use following code to get clipboard content
    * ```javascript
    * async _getContent() {


### PR DESCRIPTION
# Overview
Added `getImage` support for iOS. 

# Test Plan
1. Copy JPEG image
2. Paste the image and verify it's pasted as jpeg
3. Copy PNG image
4. Paste the image and verify it's pasted as png
5. Copy GIF image
6. Paste the image and verify it's pasted as gif


https://github.com/user-attachments/assets/2231b890-8698-49bf-be40-461d79607fc7

https://github.com/user-attachments/assets/699eea6f-3b97-4df8-be25-ab54d0821d6a



