### PR TITLE
chore(apple): fix build issues found internally

### DIFF
--- a/ios/RNCClipboard.mm
+++ b/ios/RNCClipboard.mm
@@ -179,7 +179,7 @@ RCT_EXPORT_METHOD(hasNumber:(RCTPromiseResolveBlock)resolve
   if (@available(iOS 14, *)) {
     UIPasteboard *board = [UIPasteboard generalPasteboard];
     [board detectPatternsForPatterns:[NSSet setWithObjects:UIPasteboardDetectionPatternProbableWebURL, UIPasteboardDetectionPatternNumber, UIPasteboardDetectionPatternProbableWebSearch, nil]
-                    completionHandler:^(NSSet<UIPasteboardDetectionPattern> * _Nullable set, NSError * _Nullable error) {
+                    completionHandler:^(NSSet<UIPasteboardDetectionPattern> * _Nullable set, __unused NSError * _Nullable error) {
         BOOL numberPresent = NO;
         for (NSString *type in set) {
             if ([type isEqualToString:UIPasteboardDetectionPatternNumber]) {
@@ -199,7 +199,7 @@ RCT_EXPORT_METHOD(hasWebURL:(RCTPromiseResolveBlock)resolve
   if (@available(iOS 14, *)) {
     UIPasteboard *board = [UIPasteboard generalPasteboard];
     [board detectPatternsForPatterns:[NSSet setWithObjects:UIPasteboardDetectionPatternProbableWebURL, UIPasteboardDetectionPatternNumber, UIPasteboardDetectionPatternProbableWebSearch, nil]
-                    completionHandler:^(NSSet<UIPasteboardDetectionPattern> * _Nullable set, NSError * _Nullable error) {
+                    completionHandler:^(NSSet<UIPasteboardDetectionPattern> * _Nullable set, __unused NSError * _Nullable error) {
         BOOL webURLPresent = NO;
         for (NSString *type in set) {
             if ([type isEqualToString:UIPasteboardDetectionPatternProbableWebURL]) {
@@ -238,7 +238,7 @@ RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
   // Keep: Required for RN built in Event Emitter Calls.
 }
 
-RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
+RCT_EXPORT_METHOD(removeListeners : (double)count) {
   // Keep: Required for RN built in Event Emitter Calls.
 }
 

--- a/macos/RNCClipboard.m
+++ b/macos/RNCClipboard.m
@@ -35,7 +35,7 @@ RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
   // Keep: Required for RN built in Event Emitter Calls.
 }
 
-RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
+RCT_EXPORT_METHOD(removeListeners : (double)count) {
   // Keep: Required for RN built in Event Emitter Calls.
 }
 


### PR DESCRIPTION
# Overview
At my side of Microsoft, we have recently "vendored" a couple of libraries. Which means, we started building them from source using our own generated Xcode project (not the one cocoapods generates), which has much stricter build flags / treats warnings as errors. In doing so, I caught a couple of issues in React Native Clipboard I'd like to push back up!

Namely:
- Adding `__unused` clang tags
- Changing types from `NSInteger` to `double`

# Test Plan

CI should pass, and changes are mostly innocuous