### PR TITLE
Return empty list instead of null from `getViewManagerNames`

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardPackage.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardPackage.java
@@ -31,7 +31,7 @@ public class ClipboardPackage extends TurboReactPackage implements ViewManagerOn
   /** {@inheritDoc} */
   @Override
   public List<String> getViewManagerNames(ReactApplicationContext reactContext) {
-    return null;
+    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

This PR fixes an initialization error on Android while using `@react-native-clipboard/clipboard` in a React Native 0.80.0-rc.0 app. See https://github.com/facebook/react-native/blob/77c1eb615400c07fd2a7d7f4a47dd87cef1c8743/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt#L544-L545. Note that `addAll` method requires the argument to be non-null.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
