### PR TITLE
build: added `CoreServices` dependency for the iOS pod

### DIFF
--- a/RNCClipboard.podspec
+++ b/RNCClipboard.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.ios.source_files = "ios/**/*.{h,m,mm}"
   s.osx.source_files = "macos/**/*.{h,m,mm}"
   s.visionos.source_files = "ios/**/*.{h,m,mm}"
+  s.frameworks       = 'CoreServices'
 
   if fabric_enabled
     folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'


### PR DESCRIPTION
# Overview
The iOS pod was missing `CoreServices.framework`, this dependency is needed because we use it [here](https://github.com/react-native-clipboard/clipboard/blob/master/ios/RNCClipboard.mm#L3).

This is related to: https://github.com/react-native-clipboard/clipboard/issues/269


# Test Plan
This issue cannot be replicated using the example project, which might make this PR irrelevant. 🤔 
